### PR TITLE
sfog #155: move (resting) inline as alt-word for 'hiding'

### DIFF
--- a/resources/metadata/sfog.json
+++ b/resources/metadata/sfog.json
@@ -5947,8 +5947,7 @@
           "You're callin' me to lay aside",
           "The worries of my day",
           "To quiet down my busy mind",
-          "And find a hiding place",
-          "(resting)"
+          "And find a hiding (resting) place"
         ],
         "c": [
           "Worthy You are worthy"


### PR DESCRIPTION
Per #sfog-hymnal-app feedback: `(resting)` was rendering as its own line, but in the SFOG print it sits directly under 'hiding' as an alternate word.

Fix: `"And find a hiding (resting) place"` — inline parenthetical next to the substituted word, matching the convention used for #234 (giants/he/giant keeps).