### PR TITLE
sfog #239: split parenthesized alt-words into separate chorus 2

### DIFF
--- a/resources/metadata/sfog.json
+++ b/resources/metadata/sfog.json
@@ -9348,7 +9348,7 @@
       "pages": "272",
       "author": "",
       "music": "",
-      "presentation": "v1 c v2",
+      "presentation": "v1 c v2 c2",
       "time": "",
       "meter": "",
       "theme": "",
@@ -9360,11 +9360,8 @@
           "Wash away everything, that is not pleasing to You"
         ],
         "c": [
-          "(Chorus 2 words)",
           "I will be white as snow",
-          "(So come make me white as snow)",
           "I will be pure as gold",
-          "(Lord make me pure as gold)",
           "Jesus my heart must know",
           "I'm pleasing to You",
           "I give You my life my all",
@@ -9377,6 +9374,16 @@
           "To the place where I am, only pleasing to You",
           "Purify me, I need Your light inside me",
           "So the darkness flees, and I can be pleasing to You"
+        ],
+        "c2": [
+          "So come make me white as snow",
+          "Lord make me pure as gold",
+          "Jesus my heart must know",
+          "I'm pleasing to You",
+          "I give You my life my all",
+          "Taking the cross I will follow",
+          "Jesus my heart must know",
+          "I'm pleasing to You"
         ]
       }
     },


### PR DESCRIPTION
Song 239 ("Pleasing to You") prints the chorus once with parenthesized alternate words for the second time through. Splitting those alt-words into a dedicated `c2` so each chorus renders cleanly.

- `presentation`: `v1 c v2` → `v1 c v2 c2`
- `c` lines no longer contain `(parenthesized)` alt-word cues
- New `c2` section with the alt-word version

Same pattern as #128 (parallel-column chorus split into c1/c2).