### PR TITLE
fix(data): correct lyric/title typos (#241, #238)

### DIFF
--- a/resources/metadata/shl.json
+++ b/resources/metadata/shl.json
@@ -15179,7 +15179,7 @@
       }
     },
     {
-      "title": "Crucified With Christ MY Savior",
+      "title": "Crucified With Christ My Savior",
       "songNumber": 326,
       "pages": "382, 383",
       "author": "Albert B. Simpson",


### PR DESCRIPTION
Corrects lyric/title data typos reported via the in-app Hymnal Feedback (issues filed in `Church-Life-Apps/Songs`).

## Changes in this PR

### Songs#241 — SHL song 326 title (FIXED here)
The title had `MY` in all-caps, inconsistent with the title-case of every other word. This is Albert B. Simpson's hymn "Crucified with Christ, My Savior", so "My" is correct.

- **Before:** `"Crucified With Christ MY Savior"`
- **After:**  `"Crucified With Christ My Savior"`

File: `resources/metadata/shl.json` (songNumber 326)

## Documented, no code change needed

### Songs#238 — SHL song 20 verse 7 "that" typo (ALREADY FIXED)
Brandon reported a typo on v7 around the word "that". On investigation this was **already corrected** by Resources PR #44 (commit `6ca689e`, "update song 20 lyrics"):

- **Old (buggy):** `"t makes Him precious too."`
- **Current (correct):** `"That makes Him precious too."`

The current SHL song 20 v7 now reads:
```
We praise Thee, and would praise Thee more,
To Thee our all we owe:
The precious Savior, and the pow'r
That makes Him precious too.
```
This matches the authoritative hymn text (Plymouth Brethren Archive / STEM Publishing). No further change required — the issue is resolved; closing it for tracker hygiene.

## Not addressed (left open, needs reporter info)
**Songs#235** — Samuel Faulk reported "verse 3 has a typo" with **no song number and no songbook**. Unactionable as-is; a comment was posted on the issue asking for the song number + book (SHL or SFOG). Left open intentionally.

---
JSON validated with `jq` (parses clean).

Fixes Church-Life-Apps/Songs#241
Fixes Church-Life-Apps/Songs#238